### PR TITLE
Updated code to compile with current sgt-puzzles

### DIFF
--- a/alphacrypt.c
+++ b/alphacrypt.c
@@ -1271,15 +1271,6 @@ static void free_ui(game_ui *ui)
     sfree(ui);
 }
 
-static char *encode_ui(const game_ui *ui)
-{
-    return NULL;
-}
-
-static void decode_ui(game_ui *ui, const char *encoding)
-{
-}
-
 static void game_changed_state(game_ui *ui, const game_state *oldstate,
                                const game_state *newstate)
 {
@@ -1354,7 +1345,7 @@ static char* make_move_string(const game_params *par, game_ui *ui, struct clues*
   char buf[80];
   if ((n != -1 && 
        (n > par->size || n == 0)))
-    return (ui->pending ? dupstr("o") : UI_UPDATE);
+    return (ui->pending ? dupstr("o") : MOVE_UI_UPDATE);
   sprintf(buf, "%c%c%d", (char)(ui->hpencil ? 'p' : 'r'),
           cl->letters[ui->hx*cl->rows + ui->hy], n);
   return dupstr(buf);
@@ -1427,7 +1418,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
         retstr = make_move_string(state->par, ui, state->clues, ui->pending - '0');
         abort_pending(state, ui);
       }
-      move_cursor(button, &ui->hx, &ui->hy, cols, rows, 0);
+      move_cursor(button, &ui->hx, &ui->hy, cols, rows, 0, NULL);
       ui->hshow = ui->hcursor = 1;
       return retstr;
     }
@@ -1601,7 +1592,7 @@ static game_state *execute_move(const game_state *from0, const char *move)
  */
 
 static void game_compute_size(const game_params *params, int tilesize,
-			      int *x, int *y)
+			      const game_ui *ui, int *x, int *y)
 {
   int cols = (params->size > 12 ? 2 : 1);
   int rows = (params->size > 12 ? (params->size+1)/2 : params->size);
@@ -1985,14 +1976,6 @@ static bool game_timing_state(const game_state *state, game_ui *ui)
     return true;
 }
 
-static void game_print_size(const game_params *params, float *x, float *y)
-{
-}
-
-static void game_print(drawing *dr, const game_state *state, int tilesize)
-{
-}
-
 #ifdef COMBINED
 #define thegame alphacrypt
 #endif
@@ -2011,16 +1994,19 @@ const struct game thegame = {
     new_game_desc,
     validate_desc,
     new_game,
+    NULL, /* set_public_desc */
     dup_game,
     free_game,
     true, solve_game,
     false, game_can_format_as_text_now, game_text_format,
+    NULL, NULL, /* get_prefs, set_prefs */
     new_ui,
     free_ui,
-    encode_ui,
-    decode_ui,
+    NULL, /* encode_ui */
+    NULL, /* decode_ui */
     NULL,
     game_changed_state,
+    NULL,
     interpret_move,
     execute_move,
     PREFERRED_TILESIZE, 
@@ -2034,7 +2020,7 @@ const struct game thegame = {
     game_flash_length,
     NULL,
     game_status,
-    false, false, game_print_size, game_print,
+    false, false, NULL, NULL, /* print_size, print */
     false,			       /* wants_statusbar */
     false, game_timing_state,
     0,				       /* flags */

--- a/factorcross.c
+++ b/factorcross.c
@@ -1384,15 +1384,6 @@ static void free_ui(game_ui *ui)
     sfree(ui);
 }
 
-static char *encode_ui(const game_ui *ui)
-{
-    return NULL;
-}
-
-static void decode_ui(game_ui *ui, const char *encoding)
-{
-}
-
 static void game_changed_state(game_ui *ui, const game_state *oldstate,
                                const game_state *newstate)
 {
@@ -1443,9 +1434,9 @@ static char* make_move_string(const game_params *par, game_ui *ui, int n)
         (n == 1 && par->notone_mode))) ||
       (ui->hpencil && n == 0))
 #ifdef MULTIDIGIT
-    return (ui->pending ? dupstr("O") : UI_UPDATE);
+    return (ui->pending ? dupstr("O") : MOVE_UI_UPDATE);
 #else
-    return UI_UPDATE;
+    return MOVE_UI_UPDATE;
 #endif /* MULTIDIGIT */
   sprintf(buf, "%c%d,%d,%d", (char)(ui->hpencil ? 'P' : 'R'), ui->hx, ui->hy, n);
   return dupstr(buf);
@@ -1475,7 +1466,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
     int sz = state->par->size + 1;
     int n;
     int tx, ty;
-    char* retstr = UI_UPDATE;
+    char* retstr = MOVE_UI_UPDATE;
 
     button &= ~MOD_MASK;
 
@@ -1541,7 +1532,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
         abort_pending(state, ui);
       }
 #endif /* MULTIDIGIT */
-      move_cursor(button, &ui->hx, &ui->hy, sz, sz, 0);
+      move_cursor(button, &ui->hx, &ui->hy, sz, sz, 0, NULL);
       ui->hshow = ui->hcursor = 1;
       return retstr;
     }
@@ -1780,7 +1771,7 @@ static game_state *execute_move(const game_state *from0, const char *move)
 #define SIZE(w) (((w)+1) * TILESIZE + 2*BORDER)
 
 static void game_compute_size(const game_params *params, int tilesize,
-			      int *x, int *y)
+			      const game_ui *ui, int *x, int *y)
 {
     /* Ick: fake up `ds->tilesize' for macro expansion purposes */
     struct { int tilesize; } ads, *ds = &ads;
@@ -2174,14 +2165,6 @@ static bool game_timing_state(const game_state *state, game_ui *ui)
     return true;
 }
 
-static void game_print_size(const game_params *params, float *x, float *y)
-{
-}
-
-static void game_print(drawing *dr, const game_state *state, int tilesize)
-{
-}
-
 #ifdef COMBINED
 #define thegame factorcross
 #endif
@@ -2200,16 +2183,19 @@ const struct game thegame = {
     new_game_desc,
     validate_desc,
     new_game,
+    NULL, /* set_public_desc */
     dup_game,
     free_game,
     true, solve_game,
     false, game_can_format_as_text_now, game_text_format,
+    NULL, NULL, /* get_prefs, set_prefs */
     new_ui,
     free_ui,
-    encode_ui,
-    decode_ui,
+    NULL, /* encode_ui */
+    NULL, /* decode_ui */
     NULL,
     game_changed_state,
+    NULL,
     interpret_move,
     execute_move,
     PREFERRED_TILESIZE, 
@@ -2223,7 +2209,7 @@ const struct game thegame = {
     game_flash_length,
     NULL,
     game_status,
-    false, false, game_print_size, game_print,
+    false, false, NULL, NULL, /* print_size, print */
     true,			       /* wants_statusbar */
     false, game_timing_state,
     0,				       /* flags */

--- a/identifier.c
+++ b/identifier.c
@@ -2039,15 +2039,6 @@ static void free_ui(game_ui *ui)
     sfree(ui);
 }
 
-static char *encode_ui(const game_ui *ui)
-{
-    return NULL;
-}
-
-static void decode_ui(game_ui *ui, const char *encoding)
-{
-}
-
 static void game_changed_state(game_ui *ui, const game_state *oldstate,
                                const game_state *newstate)
 {
@@ -2077,7 +2068,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
   int h = state->par->bheight;
   char pix;
   int tpanel, tx, ty;
-  char* retstr = UI_UPDATE;
+  char* retstr = MOVE_UI_UPDATE;
   char buf[20];
 
   button &= ~MOD_MASK;
@@ -2141,7 +2132,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
   if (IS_CURSOR_MOVE(button)) {
     int np = (ds->yoffd >= 0 ? 2 : 1);
     int tmpy = ui->hy + (np - ui->hpanel) * h;
-    move_cursor(button, &ui->hx, &tmpy, w, np*h + 1, 0);
+    move_cursor(button, &ui->hx, &tmpy, w, np*h + 1, 0, NULL);
     ui->hy = tmpy % h;
     ui->hpanel = np - tmpy / h;
     ui->hshow = ui->hcursor = 1;
@@ -2360,7 +2351,7 @@ enum {
 
 
 static void game_compute_size(const game_params *params, int tilesize,
-			      int *x, int *y)
+			      const game_ui* ui, int *x, int *y)
 {
   int half = tilesize / 2;
   int grsz = tilesize / 32 + 1;
@@ -2710,15 +2701,6 @@ static bool game_timing_state(const game_state *state, game_ui *ui)
     return true;
 }
 
-static void game_print_size(const game_params *params, float *x, float *y)
-{
-}
-
-static void game_print(drawing *dr, const game_state *state, int tilesize)
-{
-}
-
-
 #ifdef COMBINED
 #define thegame identifier
 #endif
@@ -2737,16 +2719,19 @@ const struct game thegame = {
     new_game_desc,
     validate_desc,
     new_game,
+    NULL, /* set_public_desc */
     dup_game,
     free_game,
     true, solve_game,
     false, game_can_format_as_text_now, game_text_format,
+    NULL, NULL, /* get_prefs, set_prefs */
     new_ui,
     free_ui,
-    encode_ui,
-    decode_ui,
+    NULL, /* encode_ui */
+    NULL, /* decode_ui */
     NULL,
     game_changed_state,
+    NULL,
     interpret_move,
     execute_move,
     PREFERRED_TILESIZE, game_compute_size, game_set_size,
@@ -2758,7 +2743,7 @@ const struct game thegame = {
     game_flash_length,
     NULL,
     game_status,
-    false, false, game_print_size, game_print,
+    false, false, NULL, NULL, /* print_size, print */
     false,			       /* wants_statusbar */
     false, game_timing_state,
     0,				       /* flags */

--- a/kakuro.c
+++ b/kakuro.c
@@ -2043,15 +2043,6 @@ static void free_ui(game_ui *ui)
     sfree(ui);
 }
 
-static char *encode_ui(const game_ui *ui)
-{
-    return NULL;
-}
-
-static void decode_ui(game_ui *ui, const char *encoding)
-{
-}
-
 static void game_changed_state(game_ui *ui, const game_state *oldstate,
                                const game_state *newstate)
 {
@@ -2101,16 +2092,16 @@ static char* make_move_string(const game_state *state, game_ui *ui, int n)
     int odd = ((state->clues->oddeven == 2 ? 0 : 1) + ui->hx + ui->hy)%2;
     if (odd ^ (n%2))
 #ifdef MULTIDIGIT
-      return (ui->pending ? dupstr("O") : UI_UPDATE);
+      return (ui->pending ? dupstr("O") : MOVE_UI_UPDATE);
 #else
-      return UI_UPDATE;
+      return MOVE_UI_UPDATE;
 #endif /* MULTIDIGIT */
   }
   if (n != -1 && (n > state->par->max || n == 0))
 #ifdef MULTIDIGIT
-    return (ui->pending ? dupstr("O") : UI_UPDATE);
+    return (ui->pending ? dupstr("O") : MOVE_UI_UPDATE);
 #else
-    return UI_UPDATE;
+    return MOVE_UI_UPDATE;
 #endif /* MULTIDIGIT */
   sprintf(buf, "%c%d,%d,%d", (char)(ui->hpencil ? 'P' : 'R'), ui->hx, ui->hy, n);
   return dupstr(buf);
@@ -2207,7 +2198,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
         abort_pending(state, ui);
       }
 #endif /* MULTIDIGIT */
-      move_cursor(button, &ui->hx, &ui->hy, sz, sz, 0);
+      move_cursor(button, &ui->hx, &ui->hy, sz, sz, 0, NULL);
       ui->hshow = ui->hcursor = 1;
       return retstr;
     }
@@ -2520,7 +2511,7 @@ static game_state *execute_move(const game_state *from0, const char *move)
 #define SIZE(w) (((w)+1) * TILESIZE + 2*BORDER)
 
 static void game_compute_size(const game_params *params, int tilesize,
-			      int *x, int *y)
+			                  const game_ui *ui, int *x, int *y)
 {
     /* Ick: fake up `ds->tilesize' for macro expansion purposes */
     struct { int tilesize; } ads, *ds = &ads;
@@ -2901,14 +2892,6 @@ static bool game_timing_state(const game_state *state, game_ui *ui)
     return true;
 }
 
-static void game_print_size(const game_params *params, float *x, float *y)
-{
-}
-
-static void game_print(drawing *dr, const game_state *state, int tilesize)
-{
-}
-
 #ifdef COMBINED
 #define thegame kakuro
 #endif
@@ -2927,16 +2910,19 @@ const struct game thegame = {
     new_game_desc,
     validate_desc,
     new_game,
+    NULL, /* set_public_desc */
     dup_game,
     free_game,
     true, solve_game,
     false, game_can_format_as_text_now, game_text_format,
+    NULL, NULL, /* get_prefs, set_prefs */
     new_ui,
     free_ui,
-    encode_ui,
-    decode_ui,
+    NULL, /* encode_ui */
+    NULL, /* decode_ui */
     NULL,
     game_changed_state,
+    NULL,
     interpret_move,
     execute_move,
     PREFERRED_TILESIZE, game_compute_size, game_set_size,
@@ -2948,7 +2934,7 @@ const struct game thegame = {
     game_flash_length,
     NULL,
     game_status,
-    false, false, game_print_size, game_print,
+    false, false, NULL, NULL, /* print_size, print */
 #ifdef SHOWDIFF
     true,			       /* wants_statusbar */
 #else

--- a/supermaze.c
+++ b/supermaze.c
@@ -2582,15 +2582,6 @@ static void free_ui(game_ui *ui)
     sfree(ui);
 }
 
-static char *encode_ui(const game_ui *ui)
-{
-    return NULL;
-}
-
-static void decode_ui(game_ui *ui, const char *encoding)
-{
-}
-
 static void game_changed_state(game_ui *ui, const game_state *oldstate,
                                const game_state *newstate)
 {
@@ -2904,7 +2895,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
           sprintf(retstr, "T");
           return dupstr(retstr);
         } else         
-          return UI_UPDATE;
+          return MOVE_UI_UPDATE;
       }
       return NULL;
     } else if (button == RIGHT_BUTTON || button == CURSOR_SELECT2) {
@@ -2989,7 +2980,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
       else if (tx >= sz-1 && ty == sz-1 && button == CURSOR_RIGHT)
         tx = sz;
       else if (!(button == CURSOR_UP && tx == -1) && !(button == CURSOR_DOWN && tx == sz))
-        move_cursor(button, &tx, &ty, sz, sz, 0);
+        move_cursor(button, &tx, &ty, sz, sz, 0, NULL);
       if ((tx != tx1 || ty != ty1) &&
           canmove(state, tx1, ty1, tx, ty, &dir)) {
         if (style == Tandem) {
@@ -3001,7 +2992,7 @@ static char *interpret_move(const game_state *state, game_ui *ui, const game_dra
           ui->tshow = 0, ui->tpos[0] = -1, ui->tpos[1] = -1;
         return dupstr(retstr);
       } else
-        return UI_UPDATE;
+        return MOVE_UI_UPDATE;
     }
 
     if ((button == 's' || button == 'S') && state->cheated && state->clues->sol) {
@@ -3110,7 +3101,7 @@ static game_state *execute_move(const game_state *from, const char *move)
  */
 
 static void game_compute_size(const game_params *params, int tilesize,
-			      int *x, int *y)
+			      const game_ui *ui, int *x, int *y)
 {
   *x = TOTSIZEX(params->size, tilesize);
   *y = TOTSIZEY(params->size, tilesize);
@@ -4129,14 +4120,6 @@ static bool game_timing_state(const game_state *state, game_ui *ui)
     return true;
 }
 
-static void game_print_size(const game_params *params, float *x, float *y)
-{
-}
-
-static void game_print(drawing *dr, const game_state *state, int tilesize)
-{
-}
-
 #ifdef COMBINED
 #define thegame supermaze
 #endif
@@ -4155,16 +4138,19 @@ const struct game thegame = {
     new_game_desc,
     validate_desc,
     new_game,
+    NULL, /* set_public_desc */
     dup_game,
     free_game,
     true, solve_game,
     false, game_can_format_as_text_now, game_text_format,
+    NULL, NULL, /* get_prefs, set_prefs */
     new_ui,
     free_ui,
-    encode_ui,
-    decode_ui,
+    NULL, /* encode_ui */
+    NULL, /* decode_ui */
     NULL,
     game_changed_state,
+    NULL,
     interpret_move,
     execute_move,
     PREFERRED_TILESIZE, 
@@ -4178,7 +4164,7 @@ const struct game thegame = {
     game_flash_length,
     NULL,
     game_status,
-    false, false, game_print_size, game_print,
+    false, false, NULL, NULL, /* print_size, print */
     false,			       /* wants_statusbar */
     false, game_timing_state,
     0,				       /* flags */


### PR DESCRIPTION
I stumbled across your extensions recently (originally because I was looking for nice kakuro implementations) and was very interested, but in the last 3 years, the upstream games repository has made a few changes. This PR fixes the breakage such that the puzzles now compile, and as best I can tell all run (although I haven't exhaustively tested beyond playing a couple of games).